### PR TITLE
add openwrt uclient fetch

### DIFF
--- a/public/snippets/shell/uclient-fetch.txt
+++ b/public/snippets/shell/uclient-fetch.txt
@@ -1,0 +1,1 @@
+uclient-fetch -U "%%useragent%%" %%url%%

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -114,5 +114,10 @@ export function languages(): {
       library: "wget",
       snippet: "shell/wget.txt"
     },
+    {
+      language: "Shell",
+      library: "uclient-fetch",
+      snippet: "shell/uclient-fetch.txt"
+    },
   ]
 }


### PR DESCRIPTION
uclient is sometimes a replacement for wget on openwrt

```cmd
Usage: uclient-fetch [options] <URL>
Options:
        -4                              Use IPv4 only
        -6                              Use IPv6 only
        -O <file>                       Redirect output to file (use "-" for stdout)
        -P <dir>                        Set directory for output files
        --quiet | -q                    Turn off status messages
        --continue | -c                 Continue a partially-downloaded file
        --header='Header: value'        Add HTTP header. Multiple allowed
        --user=<user>                   HTTP authentication username
        --password=<password>           HTTP authentication password
        --user-agent | -U <str>         Set HTTP user agent
        --post-data=STRING              use the POST method; send STRING as the data
        --post-file=FILE                use the POST method; send FILE as the data
        --spider | -s                   Spider mode - only check file existence
        --timeout=N | -T N              Set connect/request timeout to N seconds
        --proxy=on | -Y on              Enable interpretation of proxy env vars (default)
        --proxy=off | -Y off |
        --no-proxy                      Disable interpretation of proxy env vars

HTTPS options:
        --ca-certificate=<cert>         Load CA certificates from file <cert>
        --no-check-certificate          don't validate the server's certificate
        --ciphers=<cipherlist>          Set the cipher list string
```